### PR TITLE
[FEAT] 공통 앱 셸 및 GitHub OAuth 로그인 진입 화면 구현

### DIFF
--- a/src/App.test.ts
+++ b/src/App.test.ts
@@ -1,20 +1,34 @@
 import { render, screen } from '@testing-library/vue'
+import { VueQueryPlugin } from '@tanstack/vue-query'
 import { describe, expect, it } from 'vitest'
+import { vi } from 'vitest'
 
 import App from './App.vue'
 import router from './router'
 
+vi.mock('./features/auth/useAuthStatusQuery', () => ({
+  useAuthStatusQuery: () => ({
+    isPending: { value: false },
+    isAuthenticated: { value: false },
+    isUnauthorized: { value: true },
+  }),
+}))
+
 describe('App', () => {
-  it('renders the bootstrap home page', async () => {
+  it('renders the GitHub login entry screen', async () => {
     router.push('/')
     await router.isReady()
 
     render(App, {
       global: {
-        plugins: [router],
+        plugins: [router, VueQueryPlugin],
       },
     })
 
-    expect(screen.getByRole('heading', { name: /frontend workspace is ready/i })).toBeInTheDocument()
+    expect(
+      screen.getByRole('heading', {
+        name: /turn solved problems into a learning trail/i,
+      }),
+    ).toBeInTheDocument()
   })
 })

--- a/src/api/dashboard.ts
+++ b/src/api/dashboard.ts
@@ -1,0 +1,7 @@
+import { http } from './http'
+import type { ApiResponse, DashboardSummary } from '../types/api'
+
+export async function getDashboardSummary(): Promise<DashboardSummary> {
+  const response = await http.get<ApiResponse<DashboardSummary>>('/api/v1/dashboard/summary')
+  return response.data.data
+}

--- a/src/api/http.ts
+++ b/src/api/http.ts
@@ -1,0 +1,23 @@
+import axios from 'axios'
+
+import { env } from '../config/env'
+import { ApiError, type ApiResponse, type FieldErrorDetail } from '../types/api'
+
+export const http = axios.create({
+  baseURL: env.apiBaseUrl,
+  withCredentials: true,
+})
+
+http.interceptors.response.use(
+  (response) => response,
+  (error) => {
+    const response = error.response
+    const body = response?.data as Partial<ApiResponse<FieldErrorDetail[]>> | undefined
+
+    if (response && body?.status && body?.code && body?.message) {
+      return Promise.reject(new ApiError(body.status, body.code, body.message, body.data))
+    }
+
+    return Promise.reject(new ApiError(500, 'NETWORK_ERROR', '서버와 통신할 수 없습니다.'))
+  },
+)

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -1,0 +1,7 @@
+const fallbackApiBaseUrl = 'http://localhost:8080'
+const fallbackAppUrl = 'http://localhost:5173'
+
+export const env = {
+  apiBaseUrl: import.meta.env.VITE_API_BASE_URL ?? fallbackApiBaseUrl,
+  appUrl: import.meta.env.VITE_APP_URL ?? fallbackAppUrl,
+}

--- a/src/features/auth/auth.ts
+++ b/src/features/auth/auth.ts
@@ -1,0 +1,9 @@
+import { env } from '../../config/env'
+
+export function getGithubLoginUrl() {
+  return `${env.apiBaseUrl}/oauth2/authorization/github`
+}
+
+export function getLogoutUrl() {
+  return `${env.apiBaseUrl}/logout`
+}

--- a/src/features/auth/useAuthStatusQuery.ts
+++ b/src/features/auth/useAuthStatusQuery.ts
@@ -1,0 +1,24 @@
+import { computed } from 'vue'
+import { useQuery } from '@tanstack/vue-query'
+
+import { getDashboardSummary } from '../../api/dashboard'
+import { ApiError } from '../../types/api'
+
+export function useAuthStatusQuery() {
+  const query = useQuery({
+    queryKey: ['auth-status'],
+    queryFn: getDashboardSummary,
+    retry: false,
+  })
+
+  const isAuthenticated = computed(() => query.isSuccess.value)
+  const isUnauthorized = computed(
+    () => query.error.value instanceof ApiError && query.error.value.status === 401,
+  )
+
+  return {
+    ...query,
+    isAuthenticated,
+    isUnauthorized,
+  }
+}

--- a/src/layouts/AppShell.vue
+++ b/src/layouts/AppShell.vue
@@ -1,0 +1,68 @@
+<template>
+  <div class="shell-layout">
+    <aside class="shell-sidebar">
+      <div>
+        <p class="shell-kicker">
+          AlgoLog
+        </p>
+        <h1 class="shell-title">
+          Developer notebook for algorithm drills.
+        </h1>
+      </div>
+
+      <nav
+        class="shell-nav"
+        aria-label="Primary"
+      >
+        <RouterLink to="/dashboard">
+          Dashboard
+        </RouterLink>
+        <RouterLink to="/problems">
+          Problem List
+        </RouterLink>
+        <RouterLink to="/problems/new">
+          Write Note
+        </RouterLink>
+      </nav>
+
+      <a
+        class="ghost-link"
+        :href="logoutUrl"
+      >
+        Sign out
+      </a>
+    </aside>
+
+    <div class="shell-main">
+      <header class="shell-header">
+        <div>
+          <p class="shell-section-label">
+            {{ eyebrow }}
+          </p>
+          <h2>{{ title }}</h2>
+        </div>
+        <p class="shell-caption">
+          {{ description }}
+        </p>
+      </header>
+
+      <main class="shell-content">
+        <slot />
+      </main>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { RouterLink } from 'vue-router'
+
+import { getLogoutUrl } from '../features/auth/auth'
+
+defineProps<{
+  eyebrow: string
+  title: string
+  description: string
+}>()
+
+const logoutUrl = getLogoutUrl()
+</script>

--- a/src/pages/DashboardPage.vue
+++ b/src/pages/DashboardPage.vue
@@ -1,0 +1,51 @@
+<template>
+  <AppShell
+    eyebrow="Dashboard"
+    title="Study signals and weekly rhythm"
+    description="This route is protected and will be filled with summary cards and heatmap in the next feature branch."
+  >
+    <section class="placeholder-grid">
+      <article class="placeholder-card">
+        <span>Status</span>
+        <strong>{{ statusMessage }}</strong>
+      </article>
+      <article class="placeholder-card">
+        <span>Next step</span>
+        <strong>Dashboard summary and heatmap integration</strong>
+      </article>
+    </section>
+  </AppShell>
+</template>
+
+<script setup lang="ts">
+import { computed, watch } from 'vue'
+import { useRouter } from 'vue-router'
+
+import { useAuthStatusQuery } from '../features/auth/useAuthStatusQuery'
+import AppShell from '../layouts/AppShell.vue'
+
+const router = useRouter()
+const authQuery = useAuthStatusQuery()
+
+watch(authQuery.isUnauthorized, (isUnauthorized) => {
+  if (isUnauthorized) {
+    router.replace('/')
+  }
+})
+
+const statusMessage = computed(() => {
+  if (authQuery.isPending.value) {
+    return 'Checking session'
+  }
+
+  if (authQuery.isAuthenticated.value) {
+    return 'Authenticated'
+  }
+
+  if (authQuery.isUnauthorized.value) {
+    return 'Redirecting to sign-in'
+  }
+
+  return 'Unable to validate session'
+})
+</script>

--- a/src/pages/HomePage.vue
+++ b/src/pages/HomePage.vue
@@ -1,18 +1,73 @@
 <template>
-  <main class="home-page">
-    <section class="hero-card">
+  <main class="landing-page">
+    <section class="landing-panel">
       <p class="eyebrow">
-        AlgoLog Frontend
+        AlgoLog Workspace
       </p>
-      <h1>Frontend workspace is ready.</h1>
+      <h1>
+        Turn solved problems into a learning trail you can actually revisit.
+      </h1>
       <p class="lead">
-        Vue 3, TypeScript, Router, Pinia, Vue Query, lint, and test scaffolding are configured.
+        GitHub OAuth session auth is wired for the existing Spring backend. Enter through GitHub
+        and the dashboard becomes the single source of truth for session status.
       </p>
-      <ul class="status-list">
-        <li>GitHub issue and PR templates synced from backend.</li>
-        <li>Feature work will be layered on top of this baseline.</li>
-        <li>Build and test commands are available from the first PR.</li>
-      </ul>
+
+      <div class="landing-actions">
+        <a
+          class="primary-button"
+          :href="githubLoginUrl"
+        >
+          Continue with GitHub
+        </a>
+        <RouterLink
+          class="secondary-button"
+          to="/dashboard"
+        >
+          Try current session
+        </RouterLink>
+      </div>
+
+      <div class="status-grid">
+        <article class="status-card">
+          <span>Auth probe</span>
+          <strong>{{ authMessage }}</strong>
+        </article>
+        <article class="status-card">
+          <span>Protected routes</span>
+          <strong>/dashboard, /problems</strong>
+        </article>
+        <article class="status-card">
+          <span>Runtime mode</span>
+          <strong>Credential-based API client</strong>
+        </article>
+      </div>
     </section>
   </main>
 </template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { RouterLink } from 'vue-router'
+
+import { getGithubLoginUrl } from '../features/auth/auth'
+import { useAuthStatusQuery } from '../features/auth/useAuthStatusQuery'
+
+const githubLoginUrl = getGithubLoginUrl()
+const authQuery = useAuthStatusQuery()
+
+const authMessage = computed(() => {
+  if (authQuery.isPending.value) {
+    return 'Checking session...'
+  }
+
+  if (authQuery.isAuthenticated.value) {
+    return 'Authenticated session detected'
+  }
+
+  if (authQuery.isUnauthorized.value) {
+    return 'Sign in required'
+  }
+
+  return 'Probe unavailable'
+})
+</script>

--- a/src/pages/ProblemDetailPage.vue
+++ b/src/pages/ProblemDetailPage.vue
@@ -1,0 +1,16 @@
+<template>
+  <AppShell
+    eyebrow="Problem Detail"
+    title="Inspect a single algorithm note"
+    description="Detail view structure is reserved here so routing and navigation are stable before data wiring."
+  >
+    <section class="placeholder-card">
+      <span>Route</span>
+      <strong>/problems/:id</strong>
+    </section>
+  </AppShell>
+</template>
+
+<script setup lang="ts">
+import AppShell from '../layouts/AppShell.vue'
+</script>

--- a/src/pages/ProblemEditorPage.vue
+++ b/src/pages/ProblemEditorPage.vue
@@ -1,0 +1,22 @@
+<template>
+  <AppShell
+    :eyebrow="mode === 'edit' ? 'Edit Problem' : 'Write Note'"
+    :title="mode === 'edit' ? 'Update your algorithm note' : 'Capture a fresh solution record'"
+    description="Form interactions and validation will be added in the dedicated create/edit issue branch."
+  >
+    <section class="placeholder-card">
+      <span>Mode</span>
+      <strong>{{ mode }}</strong>
+    </section>
+  </AppShell>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useRoute } from 'vue-router'
+
+import AppShell from '../layouts/AppShell.vue'
+
+const route = useRoute()
+const mode = computed(() => (route.meta.mode === 'edit' ? 'edit' : 'create'))
+</script>

--- a/src/pages/ProblemsPage.vue
+++ b/src/pages/ProblemsPage.vue
@@ -1,0 +1,22 @@
+<template>
+  <AppShell
+    eyebrow="Problem List"
+    title="Search your solution history"
+    description="Problem list and filtering UI will be connected in the next issue branch."
+  >
+    <section class="placeholder-grid">
+      <article class="placeholder-card">
+        <span>Route</span>
+        <strong>/problems</strong>
+      </article>
+      <article class="placeholder-card">
+        <span>Next step</span>
+        <strong>List and detail API integration</strong>
+      </article>
+    </section>
+  </AppShell>
+</template>
+
+<script setup lang="ts">
+import AppShell from '../layouts/AppShell.vue'
+</script>

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,6 +1,10 @@
 import { createRouter, createWebHistory } from 'vue-router'
 
+import DashboardPage from '../pages/DashboardPage.vue'
 import HomePage from '../pages/HomePage.vue'
+import ProblemDetailPage from '../pages/ProblemDetailPage.vue'
+import ProblemEditorPage from '../pages/ProblemEditorPage.vue'
+import ProblemsPage from '../pages/ProblemsPage.vue'
 
 const router = createRouter({
   history: createWebHistory(),
@@ -9,6 +13,48 @@ const router = createRouter({
       path: '/',
       name: 'home',
       component: HomePage,
+    },
+    {
+      path: '/dashboard',
+      name: 'dashboard',
+      component: DashboardPage,
+      meta: {
+        requiresAuth: true,
+      },
+    },
+    {
+      path: '/problems',
+      name: 'problems',
+      component: ProblemsPage,
+      meta: {
+        requiresAuth: true,
+      },
+    },
+    {
+      path: '/problems/new',
+      name: 'problem-create',
+      component: ProblemEditorPage,
+      meta: {
+        requiresAuth: true,
+        mode: 'create',
+      },
+    },
+    {
+      path: '/problems/:id',
+      name: 'problem-detail',
+      component: ProblemDetailPage,
+      meta: {
+        requiresAuth: true,
+      },
+    },
+    {
+      path: '/problems/:id/edit',
+      name: 'problem-edit',
+      component: ProblemEditorPage,
+      meta: {
+        requiresAuth: true,
+        mode: 'edit',
+      },
     },
   ],
 })

--- a/src/style.css
+++ b/src/style.css
@@ -1,15 +1,24 @@
 :root {
-  font-family: "Segoe UI", Arial, sans-serif;
+  font-family: "Inter", "Segoe UI", Arial, sans-serif;
   line-height: 1.5;
   font-weight: 400;
   color: #e3e2e3;
   background:
-    radial-gradient(circle at top, rgba(99, 102, 241, 0.2), transparent 35%),
+    radial-gradient(circle at top, rgba(99, 102, 241, 0.22), transparent 30%),
+    radial-gradient(circle at 80% 20%, rgba(167, 202, 243, 0.12), transparent 24%),
     #121315;
   font-synthesis: none;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  --color-bg: #121315;
+  --color-surface: #1f2021;
+  --color-surface-high: #343536;
+  --color-text: #e3e2e3;
+  --color-text-muted: #c7c4d7;
+  --color-primary: #c0c1ff;
+  --color-outline: rgba(144, 143, 160, 0.2);
+  --shadow-ambient: 0 24px 48px rgba(227, 226, 227, 0.06);
 }
 
 * {
@@ -39,54 +48,205 @@ a {
   color: inherit;
 }
 
-.home-page {
+.landing-page {
   min-height: 100vh;
   display: grid;
   place-items: center;
   padding: 24px;
 }
 
-.hero-card {
-  width: min(720px, 100%);
-  padding: 40px;
+.landing-panel {
+  width: min(1080px, 100%);
+  padding: 48px;
   border-radius: 24px;
-  background: rgba(31, 32, 33, 0.88);
-  box-shadow: 0 24px 48px rgba(227, 226, 227, 0.06);
-  backdrop-filter: blur(16px);
+  background: linear-gradient(135deg, rgba(31, 32, 33, 0.96), rgba(27, 28, 29, 0.86));
+  box-shadow: var(--shadow-ambient);
+  backdrop-filter: blur(18px);
 }
 
 .eyebrow {
   margin: 0 0 12px;
-  color: #c0c1ff;
+  color: var(--color-primary);
   font-size: 0.875rem;
   letter-spacing: 0.12em;
   text-transform: uppercase;
 }
 
-.hero-card h1 {
+.landing-panel h1 {
   margin: 0;
   font-size: clamp(2rem, 4vw, 3.75rem);
   line-height: 1.05;
+  max-width: 14ch;
 }
 
 .lead {
   margin: 16px 0 0;
-  max-width: 48ch;
-  color: #c7c4d7;
+  max-width: 56ch;
+  color: var(--color-text-muted);
 }
 
-.status-list {
-  margin: 24px 0 0;
-  padding-left: 20px;
-  color: #c7c4d7;
+.landing-actions {
+  display: flex;
+  gap: 12px;
+  margin-top: 28px;
 }
 
-.status-list li + li {
-  margin-top: 8px;
+.primary-button,
+.secondary-button,
+.ghost-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 44px;
+  padding: 0 18px;
+  border-radius: 999px;
+  text-decoration: none;
+}
+
+.primary-button {
+  color: #07006c;
+  font-weight: 700;
+  background: linear-gradient(135deg, #c0c1ff, #8083ff);
+}
+
+.secondary-button,
+.ghost-link {
+  color: var(--color-text);
+  background: rgba(52, 53, 54, 0.9);
+  border: 1px solid var(--color-outline);
+}
+
+.status-grid,
+.placeholder-grid {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  margin-top: 32px;
+}
+
+.status-card,
+.placeholder-card {
+  padding: 22px;
+  border-radius: 18px;
+  background: rgba(52, 53, 54, 0.9);
+  box-shadow: var(--shadow-ambient);
+}
+
+.status-card span,
+.placeholder-card span {
+  display: block;
+  font-size: 0.82rem;
+  color: var(--color-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.status-card strong,
+.placeholder-card strong {
+  display: block;
+  margin-top: 12px;
+  font-size: 1.05rem;
+}
+
+.shell-layout {
+  min-height: 100vh;
+  display: grid;
+  grid-template-columns: 320px minmax(0, 1fr);
+}
+
+.shell-sidebar {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  padding: 32px 24px;
+  background: rgba(13, 14, 15, 0.84);
+  border-right: 1px solid var(--color-outline);
+}
+
+.shell-kicker,
+.shell-section-label {
+  margin: 0;
+  color: var(--color-primary);
+  font-size: 0.8rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.shell-title {
+  margin: 12px 0 0;
+  font-size: 2rem;
+  line-height: 1.1;
+}
+
+.shell-nav {
+  display: grid;
+  gap: 10px;
+  margin: 32px 0 auto;
+}
+
+.shell-nav a {
+  padding: 14px 16px;
+  border-radius: 16px;
+  color: var(--color-text-muted);
+  background: rgba(31, 32, 33, 0.92);
+  border: 1px solid transparent;
+}
+
+.shell-nav a.router-link-active {
+  color: var(--color-text);
+  border-color: var(--color-outline);
+  background: rgba(52, 53, 54, 0.92);
+}
+
+.shell-main {
+  padding: 28px;
+}
+
+.shell-header {
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  gap: 24px;
+}
+
+.shell-header h2 {
+  margin: 8px 0 0;
+  font-size: 2.3rem;
+}
+
+.shell-caption {
+  max-width: 40ch;
+  margin: 0;
+  color: var(--color-text-muted);
+}
+
+.shell-content {
+  margin-top: 28px;
 }
 
 @media (max-width: 640px) {
-  .hero-card {
+  .landing-panel {
     padding: 28px;
+  }
+
+  .landing-actions {
+    flex-direction: column;
+  }
+}
+
+@media (max-width: 960px) {
+  .shell-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .shell-sidebar {
+    gap: 24px;
+    border-right: 0;
+    border-bottom: 1px solid var(--color-outline);
+  }
+
+  .shell-header {
+    flex-direction: column;
+    align-items: flex-start;
   }
 }

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -1,0 +1,39 @@
+export interface ApiResponse<T> {
+  status: number
+  code: string
+  message: string
+  data: T
+}
+
+export interface FieldErrorDetail {
+  field: string
+  reason: string
+  rejectedValue: unknown
+}
+
+export class ApiError extends Error {
+  status: number
+  code: string
+  details?: FieldErrorDetail[]
+
+  constructor(status: number, code: string, message: string, details?: FieldErrorDetail[]) {
+    super(message)
+    this.name = 'ApiError'
+    this.status = status
+    this.code = code
+    this.details = details
+  }
+}
+
+export interface DashboardCount {
+  name: string
+  count: number
+}
+
+export interface DashboardSummary {
+  totalCount: number
+  solvedCount: number
+  failedCount: number
+  platformCounts: DashboardCount[]
+  difficultyCounts: DashboardCount[]
+}


### PR DESCRIPTION
## 🎫 관련 이슈 (Issue)
Closes #3

## 🛠️ 작업 내용 (Changes)
- [x] Problem List 프로젝트 톤을 반영한 공통 앱 셸과 protected 라우트 골격을 추가했습니다.
- [x] GitHub 로그인 CTA, 로그아웃 링크, `withCredentials` 기반 Axios 클라이언트, Vue Query 인증 프로브를 구성했습니다.
- [x] 홈 진입 테스트를 유지한 채 `npm run lint`, `npm run test`, `npm run build`를 통과했습니다.

## 📸 스크린샷 (Optional)
해당 없음

## 🤖 자가 점검 (Self Checklist)
- [x] 코딩 컨벤션(Java Code Style)을 준수했나요?
- [x] 불필요한 로그나 주석을 제거했나요?
- [x] 로컬 환경에서 테스트 코드를 실행하고 통과했나요?
- [x] 새로운 기능에 대한 테스트 코드를 작성했나요?

## 💬 리뷰 포인트 (Review Point)

- 인증 상태 판별을 `GET /api/v1/dashboard/summary` 성공 여부로 두었는데 현재 백엔드 세션 구조와 가장 자연스러운지 확인 부탁드립니다.
- protected 라우트 골격을 먼저 열어 두고 실제 데이터 UI는 후속 브랜치에서 채우는 방식이 개발 흐름상 괜찮은지 봐주시면 됩니다.
- 디자인 톤은 Stitch 프로젝트의 dark editorial 방향을 기반으로 추상화했으니 이후 실제 화면에 이어 붙이기 쉬운지 확인 부탁드립니다.
