### PR TITLE
[FEAT] Dashboard 화면 및 통계 연동 구현

### DIFF
--- a/src/api/dashboard.ts
+++ b/src/api/dashboard.ts
@@ -1,7 +1,12 @@
 import { http } from './http'
-import type { ApiResponse, DashboardSummary } from '../types/api'
+import type { ApiResponse, DashboardSummary, HeatmapDay } from '../types/api'
 
 export async function getDashboardSummary(): Promise<DashboardSummary> {
   const response = await http.get<ApiResponse<DashboardSummary>>('/api/v1/dashboard/summary')
+  return response.data.data
+}
+
+export async function getDashboardHeatmap(): Promise<HeatmapDay[]> {
+  const response = await http.get<ApiResponse<HeatmapDay[]>>('/api/v1/dashboard/heatmap')
   return response.data.data
 }

--- a/src/features/dashboard/heatmap.test.ts
+++ b/src/features/dashboard/heatmap.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildHeatmapColumns } from './heatmap'
+
+describe('buildHeatmapColumns', () => {
+  it('maps activity entries into weekly columns', () => {
+    const columns = buildHeatmapColumns([
+      { date: new Date().toISOString().slice(0, 10), solvedCount: 3 },
+    ])
+
+    expect(columns.length).toBeGreaterThan(50)
+    expect(columns.flat().some((cell) => cell.count === 3)).toBe(true)
+  })
+})

--- a/src/features/dashboard/heatmap.ts
+++ b/src/features/dashboard/heatmap.ts
@@ -1,0 +1,73 @@
+import type { HeatmapDay } from '../../types/api'
+
+export interface HeatmapCell {
+  key: string
+  label: string
+  count: number
+  level: 0 | 1 | 2 | 3 | 4
+}
+
+function toDateKey(date: Date) {
+  return date.toISOString().slice(0, 10)
+}
+
+function toLevel(count: number, maxCount: number): HeatmapCell['level'] {
+  if (count <= 0 || maxCount <= 0) {
+    return 0
+  }
+
+  const ratio = count / maxCount
+
+  if (ratio >= 0.75) {
+    return 4
+  }
+
+  if (ratio >= 0.5) {
+    return 3
+  }
+
+  if (ratio >= 0.25) {
+    return 2
+  }
+
+  return 1
+}
+
+export function buildHeatmapColumns(entries: HeatmapDay[]) {
+  const countMap = new Map(entries.map((entry) => [entry.date, entry.solvedCount]))
+  const maxCount = entries.reduce((max, entry) => Math.max(max, entry.solvedCount), 0)
+  const end = new Date()
+  const start = new Date(end)
+  start.setDate(end.getDate() - 364)
+
+  const calendarStart = new Date(start)
+  calendarStart.setDate(start.getDate() - start.getDay())
+
+  const columns: HeatmapCell[][] = []
+  const cursor = new Date(calendarStart)
+
+  while (cursor <= end) {
+    const column: HeatmapCell[] = []
+
+    for (let index = 0; index < 7; index += 1) {
+      const key = toDateKey(cursor)
+      const count = countMap.get(key) ?? 0
+
+      column.push({
+        key,
+        label: cursor.toLocaleDateString('ko-KR', {
+          month: 'short',
+          day: 'numeric',
+        }),
+        count,
+        level: toLevel(count, maxCount),
+      })
+
+      cursor.setDate(cursor.getDate() + 1)
+    }
+
+    columns.push(column)
+  }
+
+  return columns
+}

--- a/src/features/dashboard/useDashboardHeatmapQuery.ts
+++ b/src/features/dashboard/useDashboardHeatmapQuery.ts
@@ -1,0 +1,13 @@
+import type { Ref } from 'vue'
+import { useQuery } from '@tanstack/vue-query'
+
+import { getDashboardHeatmap } from '../../api/dashboard'
+
+export function useDashboardHeatmapQuery(enabled: Ref<boolean>) {
+  return useQuery({
+    queryKey: ['dashboard-heatmap'],
+    queryFn: getDashboardHeatmap,
+    enabled,
+    retry: false,
+  })
+}

--- a/src/pages/DashboardPage.vue
+++ b/src/pages/DashboardPage.vue
@@ -2,18 +2,135 @@
   <AppShell
     eyebrow="Dashboard"
     title="Study signals and weekly rhythm"
-    description="This route is protected and will be filled with summary cards and heatmap in the next feature branch."
+    description="Review your total attempts, success balance, platform spread, and the past year of activity without leaving one screen."
   >
-    <section class="placeholder-grid">
-      <article class="placeholder-card">
+    <template v-if="authQuery.isPending.value">
+      <section class="placeholder-grid">
+        <article class="placeholder-card">
+          <span>Status</span>
+          <strong>Checking session</strong>
+        </article>
+        <article class="placeholder-card">
+          <span>Loading</span>
+          <strong>Fetching dashboard metrics</strong>
+        </article>
+      </section>
+    </template>
+
+    <template v-else-if="authQuery.isUnauthorized.value">
+      <section class="placeholder-card">
         <span>Status</span>
-        <strong>{{ statusMessage }}</strong>
-      </article>
-      <article class="placeholder-card">
-        <span>Next step</span>
-        <strong>Dashboard summary and heatmap integration</strong>
-      </article>
-    </section>
+        <strong>Redirecting to sign-in</strong>
+      </section>
+    </template>
+
+    <template v-else-if="summary">
+      <section class="stats-grid">
+        <article class="metric-card">
+          <span>Total Notes</span>
+          <strong>{{ summary.totalCount }}</strong>
+          <p>All saved solution records in your account.</p>
+        </article>
+        <article class="metric-card">
+          <span>Solved</span>
+          <strong>{{ summary.solvedCount }}</strong>
+          <p>Successful submissions turned into study notes.</p>
+        </article>
+        <article class="metric-card">
+          <span>Failed</span>
+          <strong>{{ summary.failedCount }}</strong>
+          <p>Attempts worth revisiting before the next round.</p>
+        </article>
+      </section>
+
+      <section class="dashboard-grid">
+        <article class="panel-card heatmap-panel">
+          <div class="panel-header">
+            <div>
+              <p class="shell-section-label">
+                Heatmap
+              </p>
+              <h3>Past 12 months</h3>
+            </div>
+            <p class="panel-caption">
+              {{ heatmapCaption }}
+            </p>
+          </div>
+
+          <div
+            v-if="heatmapQuery.isLoading.value"
+            class="heatmap-fallback"
+          >
+            Loading heatmap...
+          </div>
+          <div
+            v-else-if="heatmapQuery.isError.value"
+            class="heatmap-fallback"
+          >
+            Heatmap is temporarily unavailable.
+          </div>
+          <div
+            v-else
+            class="heatmap-grid"
+          >
+            <div
+              v-for="column in heatmapColumns"
+              :key="column[0]?.key"
+              class="heatmap-column"
+            >
+              <span
+                v-for="cell in column"
+                :key="cell.key"
+                :class="['heatmap-cell', `heatmap-level-${cell.level}`]"
+                :title="`${cell.label}: ${cell.count} solved`"
+              />
+            </div>
+          </div>
+        </article>
+
+        <article class="panel-card">
+          <div class="panel-header">
+            <div>
+              <p class="shell-section-label">
+                Platform Mix
+              </p>
+              <h3>Where you practice</h3>
+            </div>
+          </div>
+
+          <ul class="distribution-list">
+            <li
+              v-for="entry in summary.platformCounts"
+              :key="entry.name"
+            >
+              <span>{{ entry.name }}</span>
+              <strong>{{ entry.count }}</strong>
+            </li>
+          </ul>
+        </article>
+
+        <article class="panel-card">
+          <div class="panel-header">
+            <div>
+              <p class="shell-section-label">
+                Difficulty Mix
+              </p>
+              <h3>Challenge distribution</h3>
+            </div>
+          </div>
+
+          <ul class="distribution-list">
+            <li
+              v-for="entry in summary.difficultyCounts"
+              :key="entry.name"
+            >
+              <span>{{ entry.name }}</span>
+              <strong>{{ entry.count }}</strong>
+            </li>
+          </ul>
+        </article>
+      </section>
+    </template>
   </AppShell>
 </template>
 
@@ -22,10 +139,13 @@ import { computed, watch } from 'vue'
 import { useRouter } from 'vue-router'
 
 import { useAuthStatusQuery } from '../features/auth/useAuthStatusQuery'
+import { buildHeatmapColumns } from '../features/dashboard/heatmap'
+import { useDashboardHeatmapQuery } from '../features/dashboard/useDashboardHeatmapQuery'
 import AppShell from '../layouts/AppShell.vue'
 
 const router = useRouter()
 const authQuery = useAuthStatusQuery()
+const heatmapQuery = useDashboardHeatmapQuery(authQuery.isAuthenticated)
 
 watch(authQuery.isUnauthorized, (isUnauthorized) => {
   if (isUnauthorized) {
@@ -33,19 +153,13 @@ watch(authQuery.isUnauthorized, (isUnauthorized) => {
   }
 })
 
-const statusMessage = computed(() => {
-  if (authQuery.isPending.value) {
-    return 'Checking session'
+const summary = computed(() => authQuery.data.value)
+const heatmapColumns = computed(() => buildHeatmapColumns(heatmapQuery.data.value ?? []))
+const heatmapCaption = computed(() => {
+  if (!heatmapQuery.data.value?.length) {
+    return 'No solved activity recorded yet.'
   }
 
-  if (authQuery.isAuthenticated.value) {
-    return 'Authenticated'
-  }
-
-  if (authQuery.isUnauthorized.value) {
-    return 'Redirecting to sign-in'
-  }
-
-  return 'Unable to validate session'
+  return `${heatmapQuery.data.value.length} active day records loaded`
 })
 </script>

--- a/src/style.css
+++ b/src/style.css
@@ -117,6 +117,7 @@ a {
 }
 
 .status-grid,
+.stats-grid,
 .placeholder-grid {
   display: grid;
   gap: 16px;
@@ -125,6 +126,7 @@ a {
 }
 
 .status-card,
+.metric-card,
 .placeholder-card {
   padding: 22px;
   border-radius: 18px;
@@ -133,6 +135,7 @@ a {
 }
 
 .status-card span,
+.metric-card span,
 .placeholder-card span {
   display: block;
   font-size: 0.82rem;
@@ -142,10 +145,20 @@ a {
 }
 
 .status-card strong,
+.metric-card strong,
 .placeholder-card strong {
   display: block;
   margin-top: 12px;
   font-size: 1.05rem;
+}
+
+.metric-card strong {
+  font-size: 2.2rem;
+}
+
+.metric-card p {
+  margin: 12px 0 0;
+  color: var(--color-text-muted);
 }
 
 .shell-layout {
@@ -224,6 +237,103 @@ a {
   margin-top: 28px;
 }
 
+.dashboard-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 2fr) minmax(280px, 1fr);
+  gap: 16px;
+  margin-top: 16px;
+}
+
+.panel-card {
+  padding: 24px;
+  border-radius: 20px;
+  background: rgba(31, 32, 33, 0.92);
+  box-shadow: var(--shadow-ambient);
+}
+
+.heatmap-panel {
+  grid-row: span 2;
+}
+
+.panel-header {
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.panel-header h3 {
+  margin: 8px 0 0;
+  font-size: 1.4rem;
+}
+
+.panel-caption {
+  margin: 0;
+  color: var(--color-text-muted);
+  font-size: 0.9rem;
+}
+
+.heatmap-grid {
+  display: grid;
+  grid-auto-flow: column;
+  grid-auto-columns: 12px;
+  gap: 6px;
+  margin-top: 24px;
+  overflow-x: auto;
+}
+
+.heatmap-column {
+  display: grid;
+  gap: 6px;
+}
+
+.heatmap-cell {
+  width: 12px;
+  height: 12px;
+  border-radius: 4px;
+  background: rgba(52, 53, 54, 0.9);
+}
+
+.heatmap-level-1 {
+  background: rgba(167, 202, 243, 0.35);
+}
+
+.heatmap-level-2 {
+  background: rgba(167, 202, 243, 0.55);
+}
+
+.heatmap-level-3 {
+  background: rgba(128, 131, 255, 0.72);
+}
+
+.heatmap-level-4 {
+  background: #c0c1ff;
+}
+
+.heatmap-fallback {
+  margin-top: 24px;
+  color: var(--color-text-muted);
+}
+
+.distribution-list {
+  list-style: none;
+  padding: 0;
+  margin: 24px 0 0;
+}
+
+.distribution-list li {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 0;
+  border-top: 1px solid var(--color-outline);
+}
+
+.distribution-list li:first-child {
+  border-top: 0;
+  padding-top: 0;
+}
+
 @media (max-width: 640px) {
   .landing-panel {
     padding: 28px;
@@ -248,5 +358,13 @@ a {
   .shell-header {
     flex-direction: column;
     align-items: flex-start;
+  }
+
+  .dashboard-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .heatmap-panel {
+    grid-row: auto;
   }
 }

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -37,3 +37,8 @@ export interface DashboardSummary {
   platformCounts: DashboardCount[]
   difficultyCounts: DashboardCount[]
 }
+
+export interface HeatmapDay {
+  date: string
+  solvedCount: number
+}


### PR DESCRIPTION
## 🎫 관련 이슈 (Issue)
Closes #5

## 🛠️ 작업 내용 (Changes)
- [x] `summary`와 `heatmap` API 타입/쿼리를 추가하고 Dashboard 페이지에 실제 데이터를 연결했습니다.
- [x] KPI 카드, 플랫폼/난이도 분포 패널, 1년 heatmap 시각화를 Stitch 톤에 맞춰 구현했습니다.
- [x] heatmap 유틸 테스트를 추가하고 `npm run lint`, `npm run test`, `npm run build`를 통과했습니다.

## 📸 스크린샷 (Optional)
해당 없음

## 🤖 자가 점검 (Self Checklist)
- [x] 코딩 컨벤션(Java Code Style)을 준수했나요?
- [x] 불필요한 로그나 주석을 제거했나요?
- [x] 로컬 환경에서 테스트 코드를 실행하고 통과했나요?
- [x] 새로운 기능에 대한 테스트 코드를 작성했나요?

## 💬 리뷰 포인트 (Review Point)

- heatmap은 최근 365일을 일요일 기준 주간 컬럼으로 펼치는데, 현재 백엔드 응답 범위와 프론트 표현 기대가 맞는지 확인 부탁드립니다.
- 요약 카드는 `summary` 응답을 그대로 쓰고, heatmap만 별도 쿼리로 분리했는데 캐시 전략상 자연스러운지 봐주시면 됩니다.
- 플랫폼/난이도 분포는 우선 정렬된 리스트 패널로 두었고, 차트화는 이후 필요 시 확장 가능한 구조입니다.
