### PR TITLE
[FEAT] Problem 등록 및 수정 화면 구현

### DIFF
--- a/src/api/solutions.ts
+++ b/src/api/solutions.ts
@@ -1,5 +1,10 @@
 import { http } from './http'
-import type { ApiResponse, Solution } from '../types/api'
+import type {
+  ApiResponse,
+  Solution,
+  SolutionCreateRequest,
+  SolutionUpdateRequest,
+} from '../types/api'
 
 export async function getSolutions(): Promise<Solution[]> {
   const response = await http.get<ApiResponse<Solution[]>>('/api/v1/solutions')
@@ -13,4 +18,17 @@ export async function getSolution(id: string | number): Promise<Solution> {
 
 export async function deleteSolution(id: string | number): Promise<void> {
   await http.delete(`/api/v1/solutions/${id}`)
+}
+
+export async function createSolution(payload: SolutionCreateRequest): Promise<Solution> {
+  const response = await http.post<ApiResponse<Solution>>('/api/v1/solutions', payload)
+  return response.data.data
+}
+
+export async function updateSolution(
+  id: string | number,
+  payload: SolutionUpdateRequest,
+): Promise<Solution> {
+  const response = await http.put<ApiResponse<Solution>>(`/api/v1/solutions/${id}`, payload)
+  return response.data.data
 }

--- a/src/features/solutions/formErrors.test.ts
+++ b/src/features/solutions/formErrors.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest'
+
+import { getFieldError } from './formErrors'
+
+describe('getFieldError', () => {
+  it('returns the matching reason for a field', () => {
+    const error = getFieldError(
+      [{ field: 'problem.title', reason: 'must not be blank', rejectedValue: '' }],
+      'problem.title',
+    )
+
+    expect(error).toBe('must not be blank')
+  })
+})

--- a/src/features/solutions/formErrors.ts
+++ b/src/features/solutions/formErrors.ts
@@ -1,0 +1,8 @@
+import type { FieldErrorDetail } from '../../types/api'
+
+export function getFieldError(
+  errors: FieldErrorDetail[] | undefined,
+  fieldName: string,
+) {
+  return errors?.find((error) => error.field === fieldName)?.reason
+}

--- a/src/features/solutions/useSaveSolutionMutation.ts
+++ b/src/features/solutions/useSaveSolutionMutation.ts
@@ -1,0 +1,16 @@
+import { useMutation } from '@tanstack/vue-query'
+
+import { createSolution, updateSolution } from '../../api/solutions'
+import type { SolutionCreateRequest, SolutionUpdateRequest } from '../../types/api'
+
+export function useCreateSolutionMutation() {
+  return useMutation({
+    mutationFn: (payload: SolutionCreateRequest) => createSolution(payload),
+  })
+}
+
+export function useUpdateSolutionMutation(id: string) {
+  return useMutation({
+    mutationFn: (payload: SolutionUpdateRequest) => updateSolution(id, payload),
+  })
+}

--- a/src/pages/ProblemEditorPage.vue
+++ b/src/pages/ProblemEditorPage.vue
@@ -2,21 +2,254 @@
   <AppShell
     :eyebrow="mode === 'edit' ? 'Edit Problem' : 'Write Note'"
     :title="mode === 'edit' ? 'Update your algorithm note' : 'Capture a fresh solution record'"
-    description="Form interactions and validation will be added in the dedicated create/edit issue branch."
+    description="Capture the problem metadata once, then keep updating the code and memo as your understanding evolves."
   >
-    <section class="placeholder-card">
-      <span>Mode</span>
-      <strong>{{ mode }}</strong>
-    </section>
+    <template v-if="isEditMode && solutionQuery.isLoading.value">
+      <section class="placeholder-card">
+        <span>Status</span>
+        <strong>Loading editor state</strong>
+      </section>
+    </template>
+
+    <template v-else>
+      <form
+        class="editor-form"
+        @submit.prevent="handleSubmit"
+      >
+        <section class="editor-grid">
+          <article class="panel-card">
+            <div class="panel-header">
+              <div>
+                <p class="shell-section-label">
+                  Problem Meta
+                </p>
+                <h3>Reference data</h3>
+              </div>
+            </div>
+
+            <div class="form-grid">
+              <label class="form-field">
+                <span>Platform</span>
+                <input
+                  v-model="form.problem.platform"
+                  :disabled="isEditMode"
+                  placeholder="BAEKJOON"
+                >
+                <small v-if="getError('problem.platform')">{{ getError('problem.platform') }}</small>
+              </label>
+
+              <label class="form-field">
+                <span>Problem ID</span>
+                <input
+                  v-model="form.problem.externalProblemId"
+                  :disabled="isEditMode"
+                  placeholder="1000"
+                >
+                <small v-if="getError('problem.externalProblemId')">{{ getError('problem.externalProblemId') }}</small>
+              </label>
+
+              <label class="form-field form-field-wide">
+                <span>Title</span>
+                <input
+                  v-model="form.problem.title"
+                  :disabled="isEditMode"
+                  placeholder="A+B"
+                >
+                <small v-if="getError('problem.title')">{{ getError('problem.title') }}</small>
+              </label>
+
+              <label class="form-field form-field-wide">
+                <span>Problem URL</span>
+                <input
+                  v-model="form.problem.problemUrl"
+                  :disabled="isEditMode"
+                  placeholder="https://www.acmicpc.net/problem/1000"
+                >
+                <small v-if="getError('problem.problemUrl')">{{ getError('problem.problemUrl') }}</small>
+              </label>
+
+              <label class="form-field">
+                <span>Difficulty</span>
+                <input
+                  v-model="form.problem.difficulty"
+                  :disabled="isEditMode"
+                  placeholder="Bronze"
+                >
+                <small v-if="getError('problem.difficulty')">{{ getError('problem.difficulty') }}</small>
+              </label>
+            </div>
+          </article>
+
+          <article class="panel-card">
+            <div class="panel-header">
+              <div>
+                <p class="shell-section-label">
+                  Solution
+                </p>
+                <h3>{{ isEditMode ? 'Refine the note' : 'Write the first version' }}</h3>
+              </div>
+            </div>
+
+            <div class="form-grid">
+              <label class="form-field">
+                <span>Execution Time (ms)</span>
+                <input
+                  v-model.number="form.timeElapsed"
+                  type="number"
+                  min="0"
+                >
+                <small v-if="getError('timeElapsed')">{{ getError('timeElapsed') }}</small>
+              </label>
+
+              <label class="form-field checkbox-field">
+                <span>Result</span>
+                <label class="checkbox-label">
+                  <input
+                    v-model="form.solved"
+                    type="checkbox"
+                  >
+                  <span>{{ form.solved ? 'Solved' : 'Retry needed' }}</span>
+                </label>
+              </label>
+
+              <label class="form-field form-field-wide">
+                <span>Code</span>
+                <textarea
+                  v-model="form.code"
+                  rows="14"
+                  placeholder="Paste your solution code"
+                />
+                <small v-if="getError('code')">{{ getError('code') }}</small>
+              </label>
+
+              <label class="form-field form-field-wide">
+                <span>Memo (Markdown)</span>
+                <textarea
+                  v-model="form.memoMarkdown"
+                  rows="12"
+                  placeholder="What did you learn? What would you revisit?"
+                />
+                <small v-if="getError('memoMarkdown')">{{ getError('memoMarkdown') }}</small>
+              </label>
+            </div>
+          </article>
+        </section>
+
+        <div class="editor-actions">
+          <RouterLink
+            class="secondary-button"
+            to="/problems"
+          >
+            Cancel
+          </RouterLink>
+          <button
+            class="primary-button button-reset"
+            type="submit"
+            :disabled="isSubmitting"
+          >
+            {{ isSubmitting ? 'Saving...' : isEditMode ? 'Update note' : 'Create note' }}
+          </button>
+        </div>
+      </form>
+    </template>
   </AppShell>
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue'
-import { useRoute } from 'vue-router'
+import { computed, reactive, watch } from 'vue'
+import { RouterLink, useRoute, useRouter } from 'vue-router'
 
+import { ApiError } from '../types/api'
+import { useAuthStatusQuery } from '../features/auth/useAuthStatusQuery'
+import { getFieldError } from '../features/solutions/formErrors'
+import { useCreateSolutionMutation, useUpdateSolutionMutation } from '../features/solutions/useSaveSolutionMutation'
+import { useSolutionQuery } from '../features/solutions/useSolutionQuery'
 import AppShell from '../layouts/AppShell.vue'
 
 const route = useRoute()
-const mode = computed(() => (route.meta.mode === 'edit' ? 'edit' : 'create'))
+const router = useRouter()
+const authQuery = useAuthStatusQuery()
+const solutionId = String(route.params.id ?? '')
+const isEditMode = computed(() => route.meta.mode === 'edit')
+const mode = computed(() => (isEditMode.value ? 'edit' : 'create'))
+const solutionQuery = useSolutionQuery(solutionId, computed(() => authQuery.isAuthenticated.value && isEditMode.value))
+const createMutation = useCreateSolutionMutation()
+const updateMutation = useUpdateSolutionMutation(solutionId)
+
+const form = reactive({
+  code: '',
+  timeElapsed: 0,
+  solved: true,
+  memoMarkdown: '',
+  problem: {
+    platform: '',
+    externalProblemId: '',
+    title: '',
+    problemUrl: '',
+    difficulty: '',
+  },
+})
+
+watch(authQuery.isUnauthorized, (isUnauthorized) => {
+  if (isUnauthorized) {
+    router.replace('/')
+  }
+})
+
+watch(
+  () => solutionQuery.data.value,
+  (solution) => {
+    if (!solution) {
+      return
+    }
+
+    form.code = solution.code
+    form.timeElapsed = solution.timeElapsed
+    form.solved = solution.solved
+    form.memoMarkdown = solution.memoMarkdown
+    form.problem.platform = solution.problem.platform
+    form.problem.externalProblemId = solution.problem.externalProblemId
+    form.problem.title = solution.problem.title
+    form.problem.problemUrl = solution.problem.problemUrl
+    form.problem.difficulty = solution.problem.difficulty
+  },
+  { immediate: true },
+)
+
+const currentError = computed(() => {
+  const error = isEditMode.value ? updateMutation.error.value : createMutation.error.value
+  return error instanceof ApiError ? error : null
+})
+
+const isSubmitting = computed(() =>
+  isEditMode.value ? updateMutation.isPending.value : createMutation.isPending.value,
+)
+
+function getError(fieldName: string) {
+  return getFieldError(currentError.value?.details, fieldName)
+}
+
+async function handleSubmit() {
+  if (isEditMode.value) {
+    const updated = await updateMutation.mutateAsync({
+      code: form.code,
+      timeElapsed: form.timeElapsed,
+      solved: form.solved,
+      memoMarkdown: form.memoMarkdown,
+    })
+
+    await router.push(`/problems/${updated.id}`)
+    return
+  }
+
+  const created = await createMutation.mutateAsync({
+    code: form.code,
+    timeElapsed: form.timeElapsed,
+    solved: form.solved,
+    memoMarkdown: form.memoMarkdown,
+    problem: { ...form.problem },
+  })
+
+  await router.push(`/problems/${created.id}`)
+}
 </script>

--- a/src/style.css
+++ b/src/style.css
@@ -444,6 +444,73 @@ a {
   gap: 16px;
 }
 
+.editor-form {
+  display: grid;
+  gap: 16px;
+}
+
+.editor-grid {
+  display: grid;
+  gap: 16px;
+}
+
+.form-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 16px;
+  margin-top: 24px;
+}
+
+.form-field {
+  display: grid;
+  gap: 8px;
+  color: var(--color-text-muted);
+}
+
+.form-field-wide {
+  grid-column: 1 / -1;
+}
+
+.form-field input,
+.form-field textarea {
+  width: 100%;
+  min-height: 46px;
+  padding: 14px 16px;
+  color: var(--color-text);
+  background: rgba(13, 14, 15, 0.92);
+  border: 1px solid var(--color-outline);
+  border-radius: 14px;
+}
+
+.form-field textarea {
+  resize: vertical;
+}
+
+.form-field small {
+  color: #ffb4ab;
+}
+
+.checkbox-field {
+  align-content: start;
+}
+
+.checkbox-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  min-height: 46px;
+}
+
+.editor-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 12px;
+}
+
+.button-reset {
+  border: 0;
+}
+
 .code-block {
   margin: 24px 0 0;
   padding: 20px;
@@ -521,6 +588,14 @@ a {
 
   .detail-actions {
     width: 100%;
+    flex-direction: column;
+  }
+
+  .form-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .editor-actions {
     flex-direction: column;
   }
 }

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -51,6 +51,29 @@ export interface Solution {
   updatedAt: string
 }
 
+export interface ProblemRequest {
+  platform: string
+  externalProblemId: string
+  title: string
+  problemUrl: string
+  difficulty: string
+}
+
+export interface SolutionCreateRequest {
+  code: string
+  timeElapsed: number
+  solved: boolean
+  memoMarkdown: string
+  problem: ProblemRequest
+}
+
+export interface SolutionUpdateRequest {
+  code: string
+  timeElapsed: number
+  solved: boolean
+  memoMarkdown: string
+}
+
 export interface DashboardSummary {
   totalCount: number
   solvedCount: number


### PR DESCRIPTION
## 🎫 관련 이슈 (Issue)
Closed #9

## 🛠️ 작업 내용 (Changes)
- [x] solution create/update 요청 타입과 mutation 훅을 추가했습니다.
- [x] create/edit 모드에 따라 문제 메타데이터와 솔루션 본문을 분기하는 폼 UI를 구현했습니다.
- [x] 서버 필드 에러 매핑을 추가하고 `npm run lint`, `npm run test`, `npm run build`를 통과했습니다.

## 📸 스크린샷 (Optional)
해당 없음

## 🤖 자가 점검 (Self Checklist)
- [x] 코딩 컨벤션(Java Code Style)을 준수했나요?
- [x] 불필요한 로그나 주석을 제거했나요?
- [x] 로컬 환경에서 테스트 코드를 실행하고 통과했나요?
- [x] 새로운 기능에 대한 테스트 코드를 작성했나요?

## 💬 리뷰 포인트 (Review Point)

- edit 모드에서 문제 메타데이터를 read-only로 둔 결정이 현재 백엔드 `PUT` 계약과 맞는지 확인 부탁드립니다.
- field error 매핑은 백엔드 `FieldErrorDetail.field`를 그대로 사용하므로 nested field 명명 규칙(`problem.title`)이 유지돼야 합니다.
- create/edit 성공 후 상세 화면으로 이동하는 단일 흐름으로 고정했는데, 작성 직후 목록 복귀보다 이쪽이 더 적절한지 봐주시면 됩니다.
