### PR TITLE
[FEAT] 로그인 후 대시보드 진입 UX 및 온보딩 개선

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ coverage
 *.njsproj
 *.sln
 *.sw?
+.omx/

--- a/src/App.test.ts
+++ b/src/App.test.ts
@@ -1,5 +1,6 @@
 import { render, screen } from '@testing-library/vue'
 import { VueQueryPlugin } from '@tanstack/vue-query'
+import { ref } from 'vue'
 import { describe, expect, it } from 'vitest'
 import { vi } from 'vitest'
 
@@ -8,9 +9,9 @@ import router from './router'
 
 vi.mock('./features/auth/useAuthStatusQuery', () => ({
   useAuthStatusQuery: () => ({
-    isPending: { value: false },
-    isAuthenticated: { value: false },
-    isUnauthorized: { value: true },
+    isPending: ref(false),
+    isAuthenticated: ref(false),
+    isUnauthorized: ref(true),
   }),
 }))
 

--- a/src/pages/DashboardPage.test.ts
+++ b/src/pages/DashboardPage.test.ts
@@ -1,0 +1,90 @@
+import { render, screen } from '@testing-library/vue'
+import { defineComponent, h, ref } from 'vue'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const replaceSpy = vi.fn()
+
+const authState = {
+  isPending: ref(false),
+  isAuthenticated: ref(true),
+  isUnauthorized: ref(false),
+  data: ref({
+    totalCount: 12,
+    solvedCount: 9,
+    failedCount: 3,
+    platformCounts: [
+      { name: 'Baekjoon', count: 8 },
+      { name: 'Programmers', count: 4 },
+    ],
+    difficultyCounts: [
+      { name: 'Silver', count: 7 },
+      { name: 'Gold', count: 5 },
+    ],
+  }),
+}
+
+const heatmapState = {
+  isLoading: ref(false),
+  isError: ref(false),
+  data: ref([]),
+}
+
+vi.mock('vue-router', () => ({
+  RouterLink: defineComponent({
+    name: 'RouterLink',
+    props: {
+      to: {
+        type: [String, Object],
+        required: false,
+        default: '/',
+      },
+    },
+    setup(props, { attrs, slots }) {
+      return () =>
+        h('a', { ...attrs, href: typeof props.to === 'string' ? props.to : '/' }, slots.default?.())
+    },
+  }),
+  useRouter: () => ({
+    replace: replaceSpy,
+  }),
+}))
+
+vi.mock('../features/auth/auth', () => ({
+  getLogoutUrl: () => '/logout',
+}))
+
+vi.mock('../features/auth/useAuthStatusQuery', () => ({
+  useAuthStatusQuery: () => authState,
+}))
+
+vi.mock('../features/dashboard/useDashboardHeatmapQuery', () => ({
+  useDashboardHeatmapQuery: () => heatmapState,
+}))
+
+import DashboardPage from './DashboardPage.vue'
+
+describe('DashboardPage', () => {
+  beforeEach(() => {
+    replaceSpy.mockReset()
+    authState.isPending.value = false
+    authState.isAuthenticated.value = true
+    authState.isUnauthorized.value = false
+  })
+
+  it('shows signed-in arrival guidance with primary and secondary actions', () => {
+    render(DashboardPage)
+
+    expect(screen.getByText(/signed in with your current github session/i)).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /write a note/i })).toHaveAttribute('href', '/problems/new')
+    expect(screen.getByRole('link', { name: /browse problem list/i })).toHaveAttribute('href', '/problems')
+  })
+
+  it('redirects unauthorized visitors back to the home page', () => {
+    authState.isAuthenticated.value = false
+    authState.isUnauthorized.value = true
+
+    render(DashboardPage)
+
+    expect(replaceSpy).toHaveBeenCalledWith('/')
+  })
+})

--- a/src/pages/DashboardPage.vue
+++ b/src/pages/DashboardPage.vue
@@ -25,6 +25,34 @@
     </template>
 
     <template v-else-if="summary">
+      <section class="arrival-card">
+        <div class="arrival-copy">
+          <p class="shell-section-label">
+            Session active
+          </p>
+          <h3>Signed in and ready to continue</h3>
+          <p class="arrival-message">
+            Signed in with your current GitHub session. Review your progress, then jump straight
+            into the next note when you are ready.
+          </p>
+        </div>
+
+        <div class="arrival-actions">
+          <RouterLink
+            class="primary-button"
+            to="/problems/new"
+          >
+            Write a note
+          </RouterLink>
+          <RouterLink
+            class="secondary-button"
+            to="/problems"
+          >
+            Browse problem list
+          </RouterLink>
+        </div>
+      </section>
+
       <section class="stats-grid">
         <article class="metric-card">
           <span>Total Notes</span>
@@ -136,7 +164,7 @@
 
 <script setup lang="ts">
 import { computed, watch } from 'vue'
-import { useRouter } from 'vue-router'
+import { RouterLink, useRouter } from 'vue-router'
 
 import { useAuthStatusQuery } from '../features/auth/useAuthStatusQuery'
 import { buildHeatmapColumns } from '../features/dashboard/heatmap'
@@ -163,3 +191,42 @@ const heatmapCaption = computed(() => {
   return `${heatmapQuery.data.value.length} active day records loaded`
 })
 </script>
+
+<style scoped>
+.arrival-card {
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  gap: 20px;
+  padding: 24px;
+  margin-bottom: 24px;
+  border: 1px solid rgba(192, 193, 255, 0.16);
+  border-radius: 20px;
+  background: rgba(31, 32, 33, 0.92);
+  box-shadow: var(--shadow-ambient);
+}
+
+.arrival-copy h3 {
+  margin: 8px 0 0;
+  font-size: 1.5rem;
+}
+
+.arrival-message {
+  max-width: 58ch;
+  margin: 12px 0 0;
+  color: var(--color-text-muted);
+}
+
+.arrival-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+@media (max-width: 900px) {
+  .arrival-card {
+    align-items: start;
+    flex-direction: column;
+  }
+}
+</style>

--- a/src/pages/HomePage.test.ts
+++ b/src/pages/HomePage.test.ts
@@ -1,0 +1,68 @@
+import { render, screen, waitFor } from '@testing-library/vue'
+import { defineComponent, h, ref } from 'vue'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const replaceSpy = vi.fn()
+
+const authState = {
+  isPending: ref(false),
+  isAuthenticated: ref(false),
+  isUnauthorized: ref(true),
+}
+
+vi.mock('vue-router', () => ({
+  RouterLink: defineComponent({
+    name: 'RouterLink',
+    props: {
+      to: {
+        type: [String, Object],
+        required: false,
+        default: '/',
+      },
+    },
+    setup(props, { slots }) {
+      return () => h('a', { href: typeof props.to === 'string' ? props.to : '/' }, slots.default?.())
+    },
+  }),
+  useRouter: () => ({
+    replace: replaceSpy,
+  }),
+}))
+
+vi.mock('../features/auth/auth', () => ({
+  getGithubLoginUrl: () => '/oauth2/authorization/github',
+}))
+
+vi.mock('../features/auth/useAuthStatusQuery', () => ({
+  useAuthStatusQuery: () => authState,
+}))
+
+import HomePage from './HomePage.vue'
+
+describe('HomePage', () => {
+  beforeEach(() => {
+    replaceSpy.mockReset()
+    authState.isPending.value = false
+    authState.isAuthenticated.value = false
+    authState.isUnauthorized.value = true
+  })
+
+  it('explains the product in user-facing language', () => {
+    render(HomePage)
+
+    expect(
+      screen.getByText(/review past notes, capture a fresh solution, and keep your practice history in one place/i),
+    ).toBeInTheDocument()
+  })
+
+  it('redirects authenticated visitors to the dashboard', async () => {
+    authState.isAuthenticated.value = true
+    authState.isUnauthorized.value = false
+
+    render(HomePage)
+
+    await waitFor(() => {
+      expect(replaceSpy).toHaveBeenCalledWith('/dashboard')
+    })
+  })
+})

--- a/src/pages/HomePage.vue
+++ b/src/pages/HomePage.vue
@@ -8,8 +8,8 @@
         Turn solved problems into a learning trail you can actually revisit.
       </h1>
       <p class="lead">
-        GitHub OAuth session auth is wired for the existing Spring backend. Enter through GitHub
-        and the dashboard becomes the single source of truth for session status.
+        Sign in with GitHub to review past notes, capture a fresh solution, and keep your practice
+        history in one place.
       </p>
 
       <div class="landing-actions">
@@ -23,22 +23,22 @@
           class="secondary-button"
           to="/dashboard"
         >
-          Try current session
+          Preview the dashboard
         </RouterLink>
       </div>
 
       <div class="status-grid">
         <article class="status-card">
-          <span>Auth probe</span>
+          <span>Session status</span>
           <strong>{{ authMessage }}</strong>
         </article>
         <article class="status-card">
-          <span>Protected routes</span>
-          <strong>/dashboard, /problems</strong>
+          <span>After sign-in</span>
+          <strong>Land on your dashboard and start the next note.</strong>
         </article>
         <article class="status-card">
-          <span>Runtime mode</span>
-          <strong>Credential-based API client</strong>
+          <span>Inside the workspace</span>
+          <strong>Dashboard, problem history, and note writing stay one click away.</strong>
         </article>
       </div>
     </section>
@@ -46,14 +46,25 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue'
-import { RouterLink } from 'vue-router'
+import { computed, watch } from 'vue'
+import { RouterLink, useRouter } from 'vue-router'
 
 import { getGithubLoginUrl } from '../features/auth/auth'
 import { useAuthStatusQuery } from '../features/auth/useAuthStatusQuery'
 
+const router = useRouter()
 const githubLoginUrl = getGithubLoginUrl()
 const authQuery = useAuthStatusQuery()
+
+watch(
+  authQuery.isAuthenticated,
+  (isAuthenticated) => {
+    if (isAuthenticated) {
+      router.replace('/dashboard')
+    }
+  },
+  { immediate: true },
+)
 
 const authMessage = computed(() => {
   if (authQuery.isPending.value) {
@@ -61,7 +72,7 @@ const authMessage = computed(() => {
   }
 
   if (authQuery.isAuthenticated.value) {
-    return 'Authenticated session detected'
+    return 'Signed in — sending you to the dashboard'
   }
 
   if (authQuery.isUnauthorized.value) {


### PR DESCRIPTION
## 🎫 관련 이슈 (Issue)
Closes #15

## 🛠️ 작업 내용 (Changes)
- [x] 홈 화면 카피를 사용자 중심 온보딩 메시지로 정리하고, 로그인된 사용자는 `/dashboard`로 바로 이동하도록 개선
- [x] 대시보드에 로그인 상태를 즉시 보여주는 안내 카드와 다음 행동 CTA 추가
- [x] 관련 프론트엔드 테스트 보강 및 `.omx/` 런타임 아티팩트 ignore 추가

## 📸 스크린샷 (Optional)
- 스크린샷은 후속 업로드 예정

## 🤖 자가 점검 (Self Checklist)
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 로그나 주석을 제거했나요?
- [x] 로컬 환경에서 테스트 코드를 실행하고 통과했나요?
- [x] 새로운 기능에 대한 테스트 코드를 작성했나요?

## 💬 리뷰 포인트 (Review Point)
- 홈 화면은 구현 세부 설명 대신 사용자 행동 중심 문구로 정리했습니다.
- 대시보드 CTA는 과밀을 피하기 위해 primary 1개 + secondary 1개로 제한했습니다.
- `npm run check`는 통과했으며, 기존 번들 chunk-size 경고는 유지됩니다.
